### PR TITLE
fix uploading big image failure by increasing ingress max-body-siz to…

### DIFF
--- a/deploy/apply/ingress.yml
+++ b/deploy/apply/ingress.yml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: {{{M3_PROJECT}}}
   namespace: {{{M3_NAMESPACE}}}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
 spec:
   rules:
     - host: '{{{M3_PROJECT}}}-{{{M3_COMPONENT}}}-{{{M3_ENVIRONMENT}}}.{{{M3_HOST_NAME}}}'


### PR DESCRIPTION
we were getting CORS issue as the upload connection got terminated by the proxy (nginx) before the request got completed. that's why the response returned doesn't even have the CORS headers. that's why we got the CORS issue. 

- [x] increase `max-body-size` for nginx proxy/ingress